### PR TITLE
add dependency to platformio file

### DIFF
--- a/library.json
+++ b/library.json
@@ -8,5 +8,11 @@
     "url": "https://github.com/horihiro/esp8266-google-home-notifier"
   },
   "frameworks": "arduino",
-  "platforms": "espressif"
+  "platforms": "espressif",
+  "dependencies":
+  [
+      {
+          "name":"esp8266-google-tts"
+      }
+  ]
 }


### PR DESCRIPTION
This way users won't have track down the tts dependency if they are using platformio