### PR TITLE
fix bug of pointer initialization

### DIFF
--- a/src/esp8266-google-home-notifier.h
+++ b/src/esp8266-google-home-notifier.h
@@ -43,7 +43,7 @@ private:
   char m_clientid[40] = {0};
 
   TTS tts;
-  WiFiClientSecure* m_client;
+  WiFiClientSecure* m_client = nullptr;
   IPAddress m_ipaddress;
   uint16_t m_port = 0;
   char m_locale[10] = "en";


### PR DESCRIPTION
It seems to be a bug in pointer initialization, so I fixed it.
With this fix my program worked fine.

crash log

```
Guru Meditation Error: Core  1 panic'ed (LoadProhibited). Exception was unhandled.
06:25:48.407 -> Core 1 register dump:
06:25:48.407 -> PC      : 0x400d4c6f  PS      : 0x00060630  A0      : 0x800d4ddc  A1      : 0x3ffb1ad0  
06:25:48.407 -> A2      : 0x00000000  A3      : 0x3f4023d0  A4      : 0xffffff70  A5      : 0x3ffb1c54  
06:25:48.407 -> A6      : 0x3ffc5968  A7      : 0xff000000  A8      : 0x800d4c4a  A9      : 0x3ffb1ab0  
06:25:48.407 -> A10     : 0x3ffb1cf0  A11     : 0xffffff70  A12     : 0x3ffb1aec  A13     : 0x3ffb1af8  
06:25:48.407 -> A14     : 0x00000015  A15     : 0x3ffb1a80  SAR     : 0x00000010  EXCCAUSE: 0x0000001c  
06:25:48.407 -> EXCVADDR: 0x00000020  LBEG    : 0x4000142d  LEND    : 0x4000143a  LCOUNT  : 0xfffffff8  
06:25:48.407 -> 
06:25:48.407 -> Backtrace: 0x400d4c6f:0x3ffb1ad0 0x400d4dd9:0x3ffb1bc0 0x400d200b:0x3ffb1be0 0x400d2d42:0x3ffb1df0 0x400d2f6e:0x3ffb1e30 0x400d23f6:0x3ffb1e60 0x400d275d:0x3ffb1ec0 0x400d29fb:0x3ffb1f50 0x400d3150:0x3ffb1f80 0x4014553e:0x3ffb1fa0
```

result of EspExceptionDecoder

```
PC: 0x400d4c6f: GoogleHomeNotifier::cast(char const*, char const*) at /Users/xxx/Documents/Arduino/libraries/esp8266-google-home-notifier/src/esp8266-google-home-notifier.cpp line 89
EXCVADDR: 0x00000020

Decoding stack results
0x400d4c6f: GoogleHomeNotifier::cast(char const*, char const*) at /Users/xxx/Documents/Arduino/libraries/esp8266-google-home-notifier/src/esp8266-google-home-notifier.cpp line 89
0x400d4dd9: GoogleHomeNotifier::notify(char const*) at /Users/xxx/Documents/Arduino/libraries/esp8266-google-home-notifier/src/esp8266-google-home-notifier.cpp line 57
0x400d200b: GoogleHome::notify(String const&) at /var/folders/rl/m5s4jvh16f14rbp8hcd888r40000gn/T/arduino_build_767626/sketch/GoogleHome.h line 31
0x400d2d42: notifyGoogleHome(String const&) at /Users/xxx/Documents/Arduino/home-iot/esp32-home/esp32-home.ino line 25
0x400d2f6e: BlynkWidgetWrite3(BlynkReq&, BlynkParam const&) at /Users/xxx/Documents/Arduino/home-iot/esp32-home/esp32-home.ino line 63
0x400d23f6: BlynkApi    > >::processCmd(void const*, unsigned int) at /Users/xxx/Documents/Arduino/libraries/Blynk/src/BlynkApiArduino.h line 188
0x400d275d: BlynkProtocol   >::processInput() at /Users/xxx/Documents/Arduino/libraries/Blynk/src/Blynk/BlynkProtocol.h line 343
0x400d29fb: BlynkProtocol   >::run(bool) at /Users/xxx/Documents/Arduino/libraries/Blynk/src/Blynk/BlynkProtocol.h line 150
0x400d3150: loop() at /Users/xxx/Documents/Arduino/home-iot/esp32-home/esp32-home.ino line 89
0x4014553e: loopTask(void*) at /Users/xxx/Library/Arduino15/packages/esp32/hardware/esp32/1.0.0/cores/esp32/main.cpp line 17
```