### PR TITLE
fix(m_name): sets default value to empty string to avoid ignoring devices named Google Home #17 and adds bool to stop calling MDNS.begin on device call

### DIFF
--- a/src/esp8266-google-home-notifier.cpp
+++ b/src/esp8266-google-home-notifier.cpp
@@ -17,9 +17,12 @@ boolean GoogleHomeNotifier::device(const char *name, const char *locale, int to)
 
   if (strcmp(this->m_name, name) != 0) {
     int i = 0;
-    if (!MDNS.begin(hostString)) {
-      this->setLastError("Failed to set up MDNS responder.");
-      return false;
+    if (!this->m_mDNSIsRunning) {
+      if (!MDNS.begin(hostString)) {
+        this->setLastError("Failed to set up MDNS responder.");
+        return false;
+      }
+      this->m_mDNSIsRunning = true;
     }
     do {
       n = MDNS.queryService("googlecast", "tcp");

--- a/src/esp8266-google-home-notifier.h
+++ b/src/esp8266-google-home-notifier.h
@@ -47,7 +47,7 @@ private:
   IPAddress m_ipaddress;
   uint16_t m_port = 0;
   char m_locale[10] = "en";
-  char m_name[128] = "Google Home";
+  char m_name[128] = "";
   char m_lastError[128] = "";
   static bool encode_string(pb_ostream_t *stream, const pb_field_t *field, void * const *arg);
   static bool decode_string(pb_istream_t *stream, const pb_field_t *field, void **arg);

--- a/src/esp8266-google-home-notifier.h
+++ b/src/esp8266-google-home-notifier.h
@@ -49,6 +49,7 @@ private:
   char m_locale[10] = "en";
   char m_name[128] = "";
   char m_lastError[128] = "";
+  bool m_mDNSIsRunning = false;
   static bool encode_string(pb_ostream_t *stream, const pb_field_t *field, void * const *arg);
   static bool decode_string(pb_istream_t *stream, const pb_field_t *field, void **arg);
   boolean connect();


### PR DESCRIPTION
Quick fix for #17 and #15 